### PR TITLE
Add dependency to documentation deployment

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,3 @@
- 
 name: Publish docs via GitHub Pages
 on:
   push:
@@ -15,7 +14,10 @@ jobs:
     steps:
       - name: Checkout main
         uses: actions/checkout@v2
-  
+
+      - name: install mkdocs
+        run: echo 'mkdocs' > requirements.txt
+
       - name: Deploy docs
         uses: mhausenblas/mkdocs-deploy-gh-pages@nomaterial
         env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,6 @@
 name: Publish docs via GitHub Pages
 on:
+  workflow_dispatch:
   push:
     branches:
       - main


### PR DESCRIPTION
Turns out the deployment Action was missing a dependency (https://github.com/mhausenblas/mkdocs-deploy-gh-pages/issues/93)

Before merging make sure Pages is switched on, with the source set to `deploy from branch` as the below screenshots

<img width="867" alt="Screen Shot 2023-01-01 at 13 23 22" src="https://user-images.githubusercontent.com/22485304/210159452-bf6e3087-afe3-4e44-bc75-b86766e39380.png">
<img width="897" alt="Screen Shot 2023-01-01 at 13 23 53" src="https://user-images.githubusercontent.com/22485304/210159453-bd49ffba-9d50-422b-b736-72e3b1297fea.png">
